### PR TITLE
Update default.html — polyfill.io depreciated

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,5 +18,5 @@
 
 </html>
 
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script src="https://polyfill-fastly.io/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>


### PR DESCRIPTION
polyfill.io was taken down in June due to security concerns. Cloudflare and Fastly have provided safe alternatives; this change uses Fastly's polyfill service with the same feature package that you originally used (es6) and should hopefully resolve the issue.