### PR TITLE
arc browser fix

### DIFF
--- a/_layouts/assignments.html
+++ b/_layouts/assignments.html
@@ -6,7 +6,7 @@ layout: page
 <ul id="archive">
 {% for asg in site.assignments %}
       <li class="archiveposturl" style="background: transparent">
-        <span><a href="{{ asg.url | prepend: site.baseurl}}">{{ asg.title }}</a></span>
+        <span><a href="{{ asg.url | append: '.html' | prepend: site.baseurl}}">{{ asg.title }}</a></span>
 <strong style="font-size:100%; font-family: 'Titillium Web', sans-serif; float:right">
 <a title="Download problems (pdf)" href="{{ asg.pdf | prepend: site.baseurl }}"><i class="fas fa-file-pdf"></i></a> 
 {% if asg.latex %}


### PR DESCRIPTION
On arc browser, if the url is to an html file that doesn't have the .html suffix, then it will just download the file. appending .html in the template fixes the issue.